### PR TITLE
Support for Laravel 5.4

### DIFF
--- a/src/Providers/SalesforceLaravelServiceProvider.php
+++ b/src/Providers/SalesforceLaravelServiceProvider.php
@@ -45,7 +45,7 @@ class SalesforceLaravelServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['salesforce'] = $this->app->share(function ($app) {
+        $this->app->singleton('salesforce', function ($app) {
             return $app->make('Frankkessler\Salesforce\Salesforce', [
                 'config' => [
                     'salesforce.logger' => $app['log'],


### PR DESCRIPTION
Unable to register the service provider. Application::share() has been removed in 5.4.