### PR TITLE
Create logger object from env

### DIFF
--- a/src/Salesforce.php
+++ b/src/Salesforce.php
@@ -43,6 +43,10 @@ class Salesforce
 
         $this->repository = new TokenRepository();
 
+        if (!empty($this->config_local["salesforce.logger"]) && is_string($this->config_local["salesforce.logger"])) {
+            $this->config_local["salesforce.logger"] = new $this->config_local["salesforce.logger"]("salesforce-rest");
+        }
+
         if (isset($this->config_local['base_uri'])) {
             $base_uri = $this->config_local['base_uri'];
         } else {

--- a/src/Salesforce.php
+++ b/src/Salesforce.php
@@ -43,8 +43,8 @@ class Salesforce
 
         $this->repository = new TokenRepository();
 
-        if (!empty($this->config_local["salesforce.logger"]) && is_string($this->config_local["salesforce.logger"])) {
-            $this->config_local["salesforce.logger"] = new $this->config_local["salesforce.logger"]("salesforce-rest");
+        if (!empty($this->config_local['salesforce.logger']) && is_string($this->config_local['salesforce.logger'])) {
+            $this->config_local['salesforce.logger'] = new $this->config_local['salesforce.logger']('salesforce-rest');
         }
 
         if (isset($this->config_local['base_uri'])) {


### PR DESCRIPTION
When not using Laravel and wanting to pass configuration in via environment variables (e.g. running in docker), there is no way currently to create a logger object to assign to the `salesforce.logger` configuration option. This code will create an object if the config option exists and is a string.