### PR TITLE
Upgrade for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     "php": ">=5.5.9",
     "guzzlehttp/guzzle":"~6.0",
     "frankkessler/guzzle-oauth2-middleware":"0.1.*",
-    "illuminate/http": "~5.1",
-    "illuminate/routing": "~5.1",
-    "illuminate/support": "~5.1",
-    "illuminate/database": "~5.1",
+    "illuminate/http": "~5.1|^6.0",
+    "illuminate/routing": "~5.1|^6.0",
+    "illuminate/support": "~5.1|^6.0",
+    "illuminate/database": "~5.1|^6.0",
     "psr/log": "~1.0"
   },
   "require-dev": {

--- a/src/SalesforceConfig.php
+++ b/src/SalesforceConfig.php
@@ -3,6 +3,7 @@
 namespace Frankkessler\Salesforce;
 
 use Config;
+use Illuminate\Support\Arr;
 
 class SalesforceConfig
 {
@@ -58,7 +59,7 @@ class SalesforceConfig
         }
         $config = ['salesforce' => $config];
 
-        return array_dot($config);
+        return Arr::dot($config);
     }
 
     public static function reset()


### PR DESCRIPTION
By updating the composer constraints, and using the Arr:: and Str:: helpers directly we can support Laravel 6. I'm currently pulling this into one of my newer Laravel 6 sites and will update the PR if I find anything else that requires fixing.